### PR TITLE
Ensure info field reflects best move when using Multi PV higher than 1

### DIFF
--- a/uci/cmd.go
+++ b/uci/cmd.go
@@ -319,8 +319,8 @@ func ProcessEngineOutput(scanner *bufio.Scanner, debugLogger *log.Logger) (*Sear
 		if err != nil {
 			continue
 		}
-		results.Info = *info
 		if info.Multipv == 1 {
+			results.Info = *info
 			// We've received the first PV line, so we can clear the multipvInfo
 			results.MultiPV = []*Info{}
 		}


### PR DESCRIPTION
**Current behaviour**
- When using Multi PV value higher than 1, the info field does not match the best move field. It is returning the last variation in the response

**Expected behaviour**
- Info line should reflect the best move line and should be the first variation, which is considered the best move.

**Fix**
- Only assign to info field when multipv value of a given line is 1. The first variation in a set.